### PR TITLE
try to fix runSpring

### DIFF
--- a/src/swipeable.tsx
+++ b/src/swipeable.tsx
@@ -825,8 +825,7 @@ export class Swipeable extends React.Component<SwipeableProps> implements Swipea
         set(config.toValue, dest),
         startClock(clock)
       ]),
-      spring(clock, state, config),
-      cond(state.finished, stopClock(clock)),
+      cond(or(eq(value, dest), state.finished), stopClock(clock), spring(clock, state, config)),
       state.position
     ])
   }


### PR DESCRIPTION
Hello, can you review these changes?

In some cases, spring animation is starting with the default animation config, but the current value is equal to the destination value.

And it seems very buggy in my cases.

It's like you tap the screen without swiping then you can see the next animation:
![Снимок экрана 2020-09-24 в 15 43 29](https://user-images.githubusercontent.com/5052136/94146523-b9832180-fe7c-11ea-89b6-5caca1abb702.png)

Maybe you know more correct way to fix it? (change spring config or conditions)